### PR TITLE
🐛 Fix `UnboundLocalError` in the decorator

### DIFF
--- a/date_operations/main.py
+++ b/date_operations/main.py
@@ -17,22 +17,22 @@ def guess_date_format(func: Callable[[str, str, str, str, Optional[List[str]]], 
         extra_formats: Optional[List[str]] = None,
     ) -> int:
         if format_1 is None:
-            guessed_format_1 = _guess_date_format(date_1, extra_formats)
+            format_1 = _guess_date_format(date_1, extra_formats)
 
-            if guessed_format_1 is None:
+            if format_1 is None:
                 raise ValueError(
                     f"Couldn't guess the date format for date_1: {date_1}."
                 )
 
         if format_2 is None:
-            guessed_format_2 = _guess_date_format(date_2, extra_formats)
+            format_2 = _guess_date_format(date_2, extra_formats)
 
-            if guessed_format_2 is None:
+            if format_2 is None:
                 raise ValueError(
                     f"Couldn't guess the date format for date_2: {date_2}."
                 )
 
-        return func(date_1, date_2, guessed_format_1, guessed_format_2, extra_formats)
+        return func(date_1, date_2, format_1, format_2, extra_formats)
 
     return _wrapper
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -231,3 +231,11 @@ def test_guess_date_format_decorator_no_guess_date_2():
         match=f"Couldn't guess the date format for date_2: {date_2}.",
     ):
         days_between(date_1, date_2)
+
+
+def test_guess_date_format_decorator_custom_format():
+    date_1 = "2023-01-01"
+    date_2 = "2023-01-11"
+
+    assert days_between(date_1, date_2, format_1="%Y-%m-%d") == 10
+    assert days_between(date_1, date_2, format_2="%Y-%m-%d") == 10


### PR DESCRIPTION
The error was being triggered when the user called the functions indicating a custom format for its dates. The error was to make reference to a variable before assigning that variable.